### PR TITLE
Remove python-typing-update pre commit plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,14 +65,6 @@ repos:
     rev: v2.7.1
     hooks:
       - id: prettier
-  - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.5.0
-    hooks:
-      - id: python-typing-update
-        args:
-          - --py38-plus
-          - --force
-          - --keep-updates
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.1
     hooks:


### PR DESCRIPTION
This PR removes the `python-typing-update` pre-commit plugin since its functionalities are covered by `pyupgrade` already. See https://github.com/cdce8p/python-typing-update/pull/211