### PR TITLE
Add install section in README and fix license in pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ This project is a re-implementation of the synchronous version
 [asyncio](https://docs.python.org/3/library/asyncio.html), where a lot of the logic is
 borrowed and improved.
 
+# Install
+
+Install with pip:
+
+```
+$ pip install aioapcaccess
+```
+
 # Usage
 
 The primary API for getting the status from APCUPS is `aioapcaccess.request_status`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 name = "aioapcaccess"
 requires-python = ">=3.8"
 description = "Async version of apcaccess library implemented in python."
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
-license = {file = 'LICENSE'}
+license = "MIT"
 authors = [
     { name = "Yuxin Wang", email = "yuxinwang.dev@gmail.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires-python = ">=3.8"
 description = "Async version of apcaccess library implemented in python."
 version = "0.2.1"
 readme = "README.md"
-license = "MIT"
+license = { text = "MIT" }
 authors = [
     { name = "Yuxin Wang", email = "yuxinwang.dev@gmail.com" }
 ]


### PR DESCRIPTION
This PR adds a install section in README and uses plain "MIT" for `license` section in `pyproject.toml` (otherwise PyPI renders the file content). 

The version number is bumped to v0.2.1 for PyPI to be refreshed.