### PR TITLE
Handle unit "C Internal"

### DIFF
--- a/aioapcaccess/__init__.py
+++ b/aioapcaccess/__init__.py
@@ -16,6 +16,7 @@ UNITS = {
     "Amps",
     "Hz",
     "C",
+    "C Internal",
     "VA",
     "Percent Load Capacity",
 }
@@ -29,7 +30,7 @@ async def request_status(
 
     :param host: the host which apcupsd is listening on.
     :param port: the port which apcupsd is listening on.
-    :return an ordered dict, where key is the field (e.g., "NOMINV") and value is the
+    :return: an ordered dict, where key is the field (e.g., "NOMINV") and value is the
     value. For example, {"NOMINV": "12.0 Volts", ..., "SERIALNO": "XXXXXXX"}
     """
     return parse_raw_status(await request_raw_status(host, port))
@@ -39,7 +40,7 @@ def parse_raw_status(raw_status: bytes) -> OrderedDict[str, str]:
     """Parse the raw status and return an ordered dict.
 
     :param raw_status: raw status string retrieved from apcupsd.
-    :return an ordered dict, where key is the field (e.g., "NOMINV") and value is the
+    :return: an ordered dict, where key is the field (e.g., "NOMINV") and value is the
     value. For example, {"NOMINV": "12.0 Volts", ..., "SERIALNO": "XXXXXXX"}
     """
     result = OrderedDict()
@@ -80,7 +81,7 @@ async def request_raw_status(host: str = "localhost", port: int = 3551) -> bytes
 
     :param host: the host which apcupsd is listening on.
     :param port: the port which apcupsd is listening on.
-    :return a bytes object containing raw status obtained from apcupsd.
+    :return: a bytes object containing raw status obtained from apcupsd.
     """
 
     reader, writer = await asyncio.open_connection(host, port)
@@ -101,7 +102,7 @@ def split_unit(value: str) -> tuple[str, str | None]:
     For the set of supported unit suffixes, see aioapcaccess.UNITS.
 
     :param value: the retrieved value string.
-    :return a tuple consisting of the value and the unit (None if not found).
+    :return: a tuple consisting of the value and the unit (None if not found).
     """
     for unit in UNITS:
         if not value.endswith(unit):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aioapcaccess"
 requires-python = ">=3.8"
 description = "Async version of apcaccess library implemented in python."
-version = "0.2.1"
+version = "0.3.0"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,7 +32,7 @@ SAMPLE_STATUS = (
     b"\x17LOTRANS  : 196.0 Volts\n\x00"
     b"\x17HITRANS  : 253.0 Volts\n\x00"
     b"\x18RETPCT   : 15.0 Percent\n\x00"
-    b"\x12ITEMP    : 30.6 C\n\x00"
+    b"\x1bITEMP    : 30.6 C Internal\n\x00"
     b"\x17ALARMDEL : Low Battery\n\x00"
     b"\x16BATTV    : 27.6 Volts\n\x00"
     b"\x13LINEFREQ : 50.0 Hz\n\x00"
@@ -89,7 +89,7 @@ PARSED_DICT = OrderedDict(
         ("LOTRANS", "196.0 Volts"),
         ("HITRANS", "253.0 Volts"),
         ("RETPCT", "15.0 Percent"),
-        ("ITEMP", "30.6 C"),
+        ("ITEMP", "30.6 C Internal"),
         ("ALARMDEL", "Low Battery"),
         ("BATTV", "27.6 Volts"),
         ("LINEFREQ", "50.0 Hz"),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -48,15 +48,16 @@ def test_parse_error():
         parse_raw_status(status)
 
 
-def test_split_unit():
-    value, unit = split_unit("15.0 Percent")
-    assert value == "15.0"
-    assert unit == "Percent"
-
-    value, unit = split_unit("16.0 Unrecognized Unit")
-    assert value == "16.0 Unrecognized Unit"
-    assert unit is None
-
-    value, unit = split_unit("18.0 Percent Load Capacity")
-    assert value == "18.0"
-    assert unit == "Percent Load Capacity"
+@pytest.mark.parametrize(
+    "raw_value,value,unit",
+    [
+        ("15.0 Percent", "15.0", "Percent"),
+        ("16.0 Unrecognized Unit", "16.0 Unrecognized Unit", None),
+        ("18.0 Percent Load Capacity", "18.0", "Percent Load Capacity"),
+        ("32.0 C Internal", "32.0", "C Internal"),
+    ],
+)
+def test_split_unit(raw_value: str, value: str, unit: str):
+    v, u = split_unit(raw_value)
+    assert v == value
+    assert u == unit


### PR DESCRIPTION
APCUPSd weirdly adds a trailing "Internal" for internal temperature ITEMP field (e.g., "30.5 C Internal" instead of "30.5 C"), which broke our simple unit inference / conversion algorithm in the integration.

This PR handles this by adding another fake unit "C Internal" to the UNIT dict. New tests are added, and the tests for `split_unit` function is further refactored to leverage `pytest.mark.parameterize` for better readability.

As a result of this, the package version is bumped to 0.3.0