### PR TITLE
Add support for "days" unit

### DIFF
--- a/aioapcaccess/__init__.py
+++ b/aioapcaccess/__init__.py
@@ -16,9 +16,15 @@ UNITS = {
     "Amps",
     "Hz",
     "C",
+    # APCUPSd reports data for "itemp" field (eventually represented by UPS Internal Temperature
+    # sensor in this integration) with a trailing "Internal", e.g., "34.6 C Internal". Here we
+    # create a fake unit " C Internal" to handle this case.
     "C Internal",
     "VA",
     "Percent Load Capacity",
+    # "stesti" field (Self Test Interval) field could report a "days" unit, e.g., "7 days", so here
+    # we add support for it.
+    "days",
 }
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,7 +42,7 @@ SAMPLE_STATUS = (
     b"\x15CUMONBATT: 0 Seconds\n\x00"
     b"\x0fXOFFBATT : N/A\n\x00"
     b"\x0eSELFTEST : NO\n\x00"
-    b"\x0fSTESTI   : 336\n\x00"
+    b"\x12STESTI   : 7 days\n\x00"
     b"\x16STATFLAG : 0x0500000A\n\x00"
     b"\x10DIPSW    : 0x00\n\x00"
     b"\x10REG1     : 0x00\n\x00"
@@ -99,7 +99,7 @@ PARSED_DICT = OrderedDict(
         ("CUMONBATT", "0 Seconds"),
         ("XOFFBATT", "N/A"),
         ("SELFTEST", "NO"),
-        ("STESTI", "336"),
+        ("STESTI", "7 days"),
         ("STATFLAG", "0x0500000A"),
         ("DIPSW", "0x00"),
         ("REG1", "0x00"),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -55,6 +55,7 @@ def test_parse_error():
         ("16.0 Unrecognized Unit", "16.0 Unrecognized Unit", None),
         ("18.0 Percent Load Capacity", "18.0", "Percent Load Capacity"),
         ("32.0 C Internal", "32.0", "C Internal"),
+        ("7 days", "7", "days"),
     ],
 )
 def test_split_unit(raw_value: str, value: str, unit: str):


### PR DESCRIPTION
This PR adds support for "days" unit since `stesti` field (Self Test Interval) field could report a "days" unit, e.g., "7 days".

Tests are updated to include this case as well.