### PR TITLE
Use setuptools-scm for dynamic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools >= 61.0", "setuptools-scm>=8.0"]
+requires = ["setuptools >= 61.0", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aioapcaccess"
 requires-python = ">=3.8"
 description = "Async version of apcaccess library implemented in python."
-version = "0.3.0"
+dynamic = ["version"]
 readme = "README.md"
 license = { text = "MIT" }
 authors = [
@@ -23,8 +23,10 @@ dev = [
 ]
 
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools >= 61.0", "setuptools-scm>=8.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
 
 [tool.black]
 line-length = 99


### PR DESCRIPTION
This PR uses `setuptools-scm` for dynamic versioning to get rid of manual version bumps.