### PR TITLE
Remove unnecessary pytest.mark.asyncio by using aysncio_mode = auto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
+    "pytest>=6.0",
     "pytest-cov",
-    "pytest-asyncio",
+    "pytest-asyncio>=0.17",
 ]
 
 [build-system]
@@ -30,6 +30,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+asyncio_mode = "auto"
 
 [tool.black]
 line-length = 99

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,7 +9,6 @@ from aioapcaccess import parse_raw_status, request_raw_status, request_status, s
 from . import PARSED_DICT, SAMPLE_STATUS
 
 
-@pytest.mark.asyncio
 async def test_request_status():
     """Test top-level API request_status."""
     with patch(
@@ -19,7 +18,6 @@ async def test_request_status():
         mock_request_raw_status.assert_called_once_with("testhost", 4242)
 
 
-@pytest.mark.asyncio
 async def test_request_raw_status():
     """Test requesting raw status from apcupsd NIC."""
     with patch("asyncio.open_connection") as mock_open_connection:


### PR DESCRIPTION
This PR removes unnecessary pytest asyncio markers by using `asyncio_mode=auto` configurations for the pytest-asyncio plugin such that aync tests are automatically discovered.

This PR also specifies the minimum versions for pytest and pytest-asyncio for `asyncio_mode=auto` support.