### PR TITLE
Use ruff for formatting and remove black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,10 +53,6 @@ repos:
     rev: v1.33.0
     hooks:
       - id: yamllint
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
       - id: ruff
         args:
           - --fix
+      - id: ruff-format
+        files: ^.*\.py$
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.15.0
     hooks:
@@ -21,12 +23,6 @@ repos:
         args:
           - --in-place
           - --remove-all-unused-imports
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
-    hooks:
-      - id: black
-        args:
-          - --quiet
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:
@@ -43,10 +39,6 @@ repos:
           - --format=custom
           - --config=pyproject.toml
         additional_dependencies: ["bandit[toml]"]
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,23 +35,10 @@ where = ["src"]
 minversion = "6.0"
 asyncio_mode = "auto"
 
-[tool.black]
-line-length = 99
-target-version = ["py38"]
-
-[tool.isort]
-atomic = true
-profile = "black"
-line_length = 99
-force_sort_within_sections = true
-skip_gitignore = true
-combine_as_imports = true
-known_first_party = ["aioapcaccess", "tests"]
-forced_separate = ["tests"]
-
 [tool.bandit]
 exclude_dirs = ["tests"]
 
 [tool.ruff]
 line-length = 99
 target-version = "py38"
+extend-select = ["I"]

--- a/src/aioapcaccess/__init__.py
+++ b/src/aioapcaccess/__init__.py
@@ -29,10 +29,7 @@ UNITS = {
 }
 
 
-async def request_status(
-    host: str = "localhost",
-    port: int = 3551,
-) -> OrderedDict[str, str]:
+async def request_status(host: str = "localhost", port: int = 3551) -> OrderedDict[str, str]:
     """Connect to the APCUPSd NIS and request its status and return the parsed dict.
 
     :param host: the host which apcupsd is listening on.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,6 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from aioapcaccess import parse_raw_status, request_raw_status, request_status, split_unit
 
 from . import PARSED_DICT, SAMPLE_STATUS


### PR DESCRIPTION
This PR removes black, isort, and prettify as formatters and use `ruff` instead.