### PR TITLE
Group dependency upgrade PRs for github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    group:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
This PR updates the dependabot configurations to group the dependency upgrade PRs for github actions.