### PR TITLE
Add token to codecov action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,4 +27,5 @@ jobs:
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Since codecoc action v4, tokenless uploads are no longer supported. This PR adds a token to the codecov action.