### PR TITLE
Fix dependabot config typo

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    group:
+    groups:
       github-actions:
         patterns:
           - "*"


### PR DESCRIPTION
This PR fixes a typo in the dependabot config (`group` -> `groups`).