### PR TITLE
Bump minimum version of python to 3.9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.x", "pypy3.8"]
+        python-version: ["3.9", "3.x", "pypy3.9"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aioapcaccess"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 description = "Async version of apcaccess library implemented in python."
 dynamic = ["version"]
 readme = "README.md"
@@ -40,7 +40,7 @@ exclude_dirs = ["tests"]
 
 [tool.ruff]
 line-length = 99
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 extend-select = ["I"]


### PR DESCRIPTION
Python 3.8 has been EoL since last year, so this PR bumps up the minimum supported python version to 3.9.