### PR TITLE
Migrate from basedpyright to ty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: v1.37.1
     hooks:
       - id: yamllint
-  - repo: https://github.com/DetachHead/basedpyright-prek-mirror
-    rev: 1.36.2
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.58
     hooks:
-      - id: basedpyright
+      - id: ty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ target-version = "py310"
 [tool.ruff.lint]
 extend-select = ["I"]
 
-[tool.basedpyright]
-typeCheckingMode = "strict"
-# Disable unused call result warnings since it is too noisy in practice.
-reportUnusedCallResult = "none"
+[tool.ty.rules]
+missing-type-argument = "error"
+possibly-unresolved-reference = "warn"


### PR DESCRIPTION
## Summary

- replace the basedpyright prek hook with the official ty hook
- replace basedpyright configuration with ty strictness rules
- remove all basedpyright references

## Validation

- `prek run --all-files --color=never`
- `uv run --frozen --extra dev pytest -q`
- `git diff --check`